### PR TITLE
docs: Add Information about Package Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ A set of JavaScript modules to handle binary data in JS (using Typed Arrays).  I
   * bitjs/io: Low-level classes for interpreting binary data (BitStream, ByteStream).  For example, reading or peeking at N bits at a time.
 
 
+## Installation
+
+Install it using your favourite package manager, the package is registered under `@codedread/bitjs`. 
+```bash
+$ yarn add @codedread/bitjs
+```
+
 ## Example Usage
 
 ### bitjs.archive


### PR DESCRIPTION
For an amateur in the Node world, checking for the package name under the `package.json` wasn't a reflex. Hope this makes it easier for people who try ```yarn add bit-js``` first and wonder why the packages aren't the same. 